### PR TITLE
MaterialConverter fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- Spigot properties -->
-        <spigot.version>1.17.1</spigot.version>
+        <spigot.version>1.18.1</spigot.version>
         <spigot.javadocs>https://hub.spigotmc.org/javadocs/spigot/</spigot.javadocs>
 
         <!-- Default settings for sonarcloud.io -->

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,12 @@
     </build>
 
     <dependencies>
+	    <dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.22</version>
+			<scope>provided</scope>
+		</dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -193,12 +193,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>${spigot.version}-R0.1-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -192,12 +192,12 @@
     </build>
 
     <dependencies>
-	    <dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.22</version>
-			<scope>provided</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.22</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/MinecraftVersion.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/MinecraftVersion.java
@@ -49,7 +49,7 @@ public enum MinecraftVersion {
      * (The "Caves and Cliffs: Part II" Update)
      *
      */
-    MINECRAFT_1_18(17, "1.18.x"),
+    MINECRAFT_1_18(18, "1.18.x"),
 
     /**
      * This constant represents an exceptional state in which we were unable

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/MinecraftVersion.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/api/MinecraftVersion.java
@@ -43,6 +43,13 @@ public enum MinecraftVersion {
      *
      */
     MINECRAFT_1_17(17, "1.17.x"),
+    
+    /**
+     * This constant represents Minecraft (Java Edition) Version 1.18
+     * (The "Caves and Cliffs: Part II" Update)
+     *
+     */
+    MINECRAFT_1_18(17, "1.18.x"),
 
     /**
      * This constant represents an exceptional state in which we were unable

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoForester.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/AutoForester.java
@@ -19,6 +19,7 @@ import org.bukkit.inventory.ShapedRecipe;
 
 import io.github.thebusybiscuit.sensibletoolbox.api.items.AutoFarmingMachine;
 import io.github.thebusybiscuit.sensibletoolbox.items.components.MachineFrame;
+import io.github.thebusybiscuit.sensibletoolbox.utils.MaterialConverter;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.Vein;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/Sawmill.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/blocks/machines/Sawmill.java
@@ -17,6 +17,7 @@ import io.github.thebusybiscuit.sensibletoolbox.api.recipes.CustomRecipeManager;
 import io.github.thebusybiscuit.sensibletoolbox.api.recipes.SimpleCustomRecipe;
 import io.github.thebusybiscuit.sensibletoolbox.items.components.MachineFrame;
 import io.github.thebusybiscuit.sensibletoolbox.items.components.SimpleCircuit;
+import io.github.thebusybiscuit.sensibletoolbox.utils.MaterialConverter;
 
 public class Sawmill extends AbstractIOMachine {
 

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/PaintBrush.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/items/PaintBrush.java
@@ -30,17 +30,19 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.material.Colorable;
-
-import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.sensibletoolbox.api.SensibleToolbox;
+import io.github.thebusybiscuit.sensibletoolbox.api.gui.GUIUtil;
+import io.github.thebusybiscuit.sensibletoolbox.api.gui.InventoryGUI;
+import io.github.thebusybiscuit.sensibletoolbox.api.gui.gadgets.ButtonGadget;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBBlock;
 import io.github.thebusybiscuit.sensibletoolbox.api.items.BaseSTBItem;
 import io.github.thebusybiscuit.sensibletoolbox.blocks.PaintCan;
 import io.github.thebusybiscuit.sensibletoolbox.utils.HoloMessage;
 import io.github.thebusybiscuit.sensibletoolbox.utils.STBUtil;
 import io.github.thebusybiscuit.sensibletoolbox.utils.UnicodeSymbol;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import me.desht.dhutils.Debugger;
-import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 
 public class PaintBrush extends BaseSTBItem {
 
@@ -207,6 +209,9 @@ public class PaintBrush extends BaseSTBItem {
 
     @Override
     public void onInteractEntity(PlayerInteractEntityEvent event) {
+    	if(!event.getHand().equals(EquipmentSlot.HAND)) {
+    		return;
+    	}
         event.setCancelled(true);
 
         if (getPaintLevel() <= 0) {
@@ -262,10 +267,15 @@ public class PaintBrush extends BaseSTBItem {
         find(b.getRelative(BlockFace.DOWN), mat, blocks, max);
     }
 
-    @Nullable
+	@Nullable
     private DyeColor getBlockColor(@Nonnull Block b) {
         if (STBUtil.isColorable(b.getType())) {
-            return DyeColor.getByColor(getColor().getColor());
+        	String name = b.getType().name();
+        	String color = name.split("_")[0];
+			if(color.equals("LIGHT")) {
+				color += "_"+name.split("_")[1];
+			}
+			return DyeColor.valueOf(color);
         } else {
             return null;
         }
@@ -274,34 +284,38 @@ public class PaintBrush extends BaseSTBItem {
     private int paintBlocks(@Nonnull Player player, Block... blocks) {
         int painted = 0;
 
-        // TODO: Get Paint Brush working again
-        // for (Block b : blocks) {
-        // if (!SensibleToolbox.getProtectionManager().hasPermission(player, b, ProtectableAction.PLACE_BLOCK)) {
-        // continue;
-        // }
-        //
-        // Debugger.getInstance().debug(2, "painting! " + b + " " + getPaintLevel() + " " + getColor());
-        // BaseSTBBlock stb = SensibleToolbox.getBlockAt(b.getLocation());
-        //
-        // if (stb instanceof Colorable) {
-        // ((Colorable) stb).setColor(getColor());
-        // }
-        // else {
-        // if (b.getType() == Material.GLASS) {
-        // b.setType(Material.STAINED_GLASS);
-        // }
-        // else if (b.getType() == Material.GLASS_PANE) {
-        // b.setType(Material.STAINED_GLASS_PANE);
-        // }
-        // }
-        //
-        // painted++;
-        // setPaintLevel(getPaintLevel() - 1);
-        //
-        // if (getPaintLevel() <= 0) {
-        // break;
-        // }
-        // }
+		for (Block b : blocks) {
+			if (!SensibleToolbox.getProtectionManager().hasPermission(player, b, Interaction.PLACE_BLOCK)) {
+				continue;
+			}
+
+			Debugger.getInstance().debug(2, "painting! " + b + " " + getPaintLevel() + " " + getColor());
+			
+			if (b.getType() == Material.GLASS) {
+				b.setType(Material.WHITE_STAINED_GLASS);
+			} else if (b.getType() == Material.GLASS_PANE) {
+				b.setType(Material.WHITE_STAINED_GLASS_PANE);
+			} else {
+				if (!STBUtil.isColorable(b.getType())) {
+					continue;
+				}
+
+				String name = b.getType().name();
+				String oldCol = name.split("_")[0];
+				if (oldCol.equals("LIGHT")) {
+					oldCol += "_" + name.split("_")[1];
+				}
+				name = name.replace(oldCol, getColor().name());
+				b.setType(Material.valueOf(name));
+			}
+
+			painted++;
+			setPaintLevel(getPaintLevel() - 1);
+
+			if (getPaintLevel() <= 0) {
+				break;
+			}
+		}
         return painted;
     }
 
@@ -309,25 +323,23 @@ public class PaintBrush extends BaseSTBItem {
         Painting editingPainting = painting;
 
         Art[] other = getOtherArt(painting.getArt());
-        ChestMenu menu = new ChestMenu("Select Artwork");
-        menu.setEmptySlotsClickable(false);
-        menu.setPlayerInventoryClickable(false);
-
+        InventoryGUI menu = GUIUtil.createGUI(p, this,9, ChatColor.DARK_PURPLE + "Select Artwork");
+        
         int i = 0;
         for (Art art : other) {
-            menu.addItem(i, new CustomItemStack(Material.PAINTING, art.name(), "", "&7Click to select this artwork"), (pl, slot, item, action) -> {
-                editingPainting.setArt(art);
-                setPaintLevel(getPaintLevel() - art.getBlockWidth() * art.getBlockHeight());
-                updateHeldItemStack(pl, hand);
-                pl.playSound(editingPainting.getLocation(), Sound.BLOCK_WATER_AMBIENT, 1.0F, 1.5F);
-                pl.closeInventory();
-                return false;
-            });
-
+        	menu.addGadget(new ButtonGadget(menu,i,new CustomItemStack(Material.PAINTING, art.name(), "", "&7Click to select this artwork"),new Runnable() {
+				@Override
+				public void run() {
+					editingPainting.setArt(art);
+	                setPaintLevel(getPaintLevel() - art.getBlockWidth() * art.getBlockHeight());
+	                updateHeldItemStack(p, hand);
+	                p.playSound(editingPainting.getLocation(), Sound.BLOCK_WATER_AMBIENT, 1.0F, 1.5F);
+	                p.closeInventory();
+				}
+        	}));
             i++;
         }
-
-        menu.open(p);
+        menu.show(p);
     }
 
     @Nonnull

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
@@ -4,8 +4,10 @@ import java.util.Optional;
 
 import org.bukkit.Material;
 
+import lombok.NonNull;
+
 public final class MaterialConverter {
-	public static Optional<Material> getSaplingFromLog(Material log) {
+	public static Optional<Material> getSaplingFromLog(@NonNull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
 
@@ -18,7 +20,7 @@ public final class MaterialConverter {
 		}
 	}
 
-	public static Optional<Material> getPlanksFromLog(Material log) {
+	public static Optional<Material> getPlanksFromLog(@NonNull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
 
@@ -31,7 +33,7 @@ public final class MaterialConverter {
 		}
 	}
 
-	public static boolean isLog(Material log) {
+	public static boolean isLog(@NonNull Material log) {
 		return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
 	}
 }

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
@@ -1,0 +1,37 @@
+package io.github.thebusybiscuit.sensibletoolbox.utils;
+
+import java.util.Optional;
+
+import org.bukkit.Material;
+
+public final class MaterialConverter {
+	public static Optional<Material> getSaplingFromLog(Material log) {
+		if (!isLog(log))
+			return Optional.empty();
+
+		String type = log.name().substring(0, log.name().lastIndexOf('_'));
+		type = type.replace("STRIPPED_", "");
+		try {
+			return Optional.ofNullable(Material.valueOf(type + "_SAPLING"));
+		} catch (IllegalArgumentException ignored) {
+			return Optional.empty();
+		}
+	}
+
+	public static Optional<Material> getPlanksFromLog(Material log) {
+		if (!isLog(log))
+			return Optional.empty();
+
+		String type = log.name().substring(0, log.name().lastIndexOf('_'));
+		type = type.replace("STRIPPED_", "");
+		try {
+			return Optional.ofNullable(Material.valueOf(type + "_PLANKS"));
+		} catch (IllegalArgumentException ignored) {
+			return Optional.empty();
+		}
+	}
+
+	public static boolean isLog(Material log) {
+		return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
+	}
+}

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
@@ -10,51 +10,51 @@ import org.bukkit.Material;
  * A collection of miscellaneous material-related utility methods.
  */
 public final class MaterialConverter {
-	/**
-	 * Turn log into sapling preserving tree type
-	 *
-	 * @param log log you want to turn into sapling
-	 * @return sapling
-	 */
-	public static Optional<Material> getSaplingFromLog(@Nonnull Material log) {
-		if (!isLog(log))
-			return Optional.empty();
+    /**
+     * Turn log into sapling preserving tree type
+     *
+     * @param log log you want to turn into sapling
+     * @return sapling
+     */
+    public static Optional<Material> getSaplingFromLog(@Nonnull Material log) {
+        if (!isLog(log))
+            return Optional.empty();
 
-		String type = log.name().substring(0, log.name().lastIndexOf('_'));
-		type = type.replace("STRIPPED_", "");
-		try {
-			return Optional.ofNullable(Material.valueOf(type + "_SAPLING"));
-		} catch (IllegalArgumentException ignored) {
-			return Optional.empty();
-		}
-	}
+        String type = log.name().substring(0, log.name().lastIndexOf('_'));
+        type = type.replace("STRIPPED_", "");
+        try {
+            return Optional.ofNullable(Material.valueOf(type + "_SAPLING"));
+        } catch (IllegalArgumentException ignored) {
+            return Optional.empty();
+        }
+    }
 
-	/**
-	 * Turn log into planks preserving tree type
-	 *
-	 * @param log log you want to turn into planks
-	 * @return planks
-	 */
-	public static Optional<Material> getPlanksFromLog(@Nonnull Material log) {
-		if (!isLog(log))
-			return Optional.empty();
+    /**
+     * Turn log into planks preserving tree type
+     *
+     * @param log log you want to turn into planks
+     * @return planks
+     */
+    public static Optional<Material> getPlanksFromLog(@Nonnull Material log) {
+        if (!isLog(log))
+            return Optional.empty();
 
-		String type = log.name().substring(0, log.name().lastIndexOf('_'));
-		type = type.replace("STRIPPED_", "");
-		try {
-			return Optional.ofNullable(Material.valueOf(type + "_PLANKS"));
-		} catch (IllegalArgumentException ignored) {
-			return Optional.empty();
-		}
-	}
+        String type = log.name().substring(0, log.name().lastIndexOf('_'));
+        type = type.replace("STRIPPED_", "");
+        try {
+            return Optional.ofNullable(Material.valueOf(type + "_PLANKS"));
+        } catch (IllegalArgumentException ignored) {
+            return Optional.empty();
+        }
+    }
 
-	/**
-	 * Check if material is log (any type)
-	 *
-	 * @param log the material to check
-	 * @return true if the stack is log; false otherwise
-	 */
-	public static boolean isLog(@Nonnull Material log) {
-		return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
-	}
+    /**
+     * Check if material is log (any type)
+     *
+     * @param log the material to check
+     * @return true if the stack is log; false otherwise
+     */
+    public static boolean isLog(@Nonnull Material log) {
+        return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
+    }
 }

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
@@ -6,14 +6,16 @@ import org.bukkit.Material;
 
 import lombok.NonNull;
 
+/**
+ * A collection of miscellaneous material-related utility methods.
+ */
 public final class MaterialConverter {
 	/**
-     * Turn log into sapling preserving tree type
-     *
-     * @param log
-     *           log  you want to turn into sapling
-     * @return sapling
-     */
+	 * Turn log into sapling preserving tree type
+	 *
+	 * @param log log you want to turn into sapling
+	 * @return sapling
+	 */
 	public static Optional<Material> getSaplingFromLog(@NonNull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
@@ -26,13 +28,13 @@ public final class MaterialConverter {
 			return Optional.empty();
 		}
 	}
+
 	/**
-     * Turn log into planks preserving tree type
-     *
-     * @param log
-     *           log you want to turn into planks
-     * @return planks
-     */
+	 * Turn log into planks preserving tree type
+	 *
+	 * @param log log you want to turn into planks
+	 * @return planks
+	 */
 	public static Optional<Material> getPlanksFromLog(@NonNull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
@@ -45,13 +47,13 @@ public final class MaterialConverter {
 			return Optional.empty();
 		}
 	}
+
 	/**
-     * Check if material is log (any type)
-     *
-     * @param log
-     *            the material to check
-     * @return true if the stack is log; false otherwise
-     */
+	 * Check if material is log (any type)
+	 *
+	 * @param log the material to check
+	 * @return true if the stack is log; false otherwise
+	 */
 	public static boolean isLog(@NonNull Material log) {
 		return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
 	}

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
@@ -7,6 +7,13 @@ import org.bukkit.Material;
 import lombok.NonNull;
 
 public final class MaterialConverter {
+	/**
+     * Turn log into sapling preserving tree type
+     *
+     * @param log
+     *           log  you want to turn into sapling
+     * @return sapling
+     */
 	public static Optional<Material> getSaplingFromLog(@NonNull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
@@ -19,7 +26,13 @@ public final class MaterialConverter {
 			return Optional.empty();
 		}
 	}
-
+	/**
+     * Turn log into planks preserving tree type
+     *
+     * @param log
+     *           log you want to turn into planks
+     * @return planks
+     */
 	public static Optional<Material> getPlanksFromLog(@NonNull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
@@ -32,7 +45,13 @@ public final class MaterialConverter {
 			return Optional.empty();
 		}
 	}
-
+	/**
+     * Check if material is log (any type)
+     *
+     * @param log
+     *            the material to check
+     * @return true if the stack is log; false otherwise
+     */
 	public static boolean isLog(@NonNull Material log) {
 		return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
 	}

--- a/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
+++ b/src/main/java/io/github/thebusybiscuit/sensibletoolbox/utils/MaterialConverter.java
@@ -2,9 +2,9 @@ package io.github.thebusybiscuit.sensibletoolbox.utils;
 
 import java.util.Optional;
 
-import org.bukkit.Material;
+import javax.annotation.Nonnull;
 
-import lombok.NonNull;
+import org.bukkit.Material;
 
 /**
  * A collection of miscellaneous material-related utility methods.
@@ -16,7 +16,7 @@ public final class MaterialConverter {
 	 * @param log log you want to turn into sapling
 	 * @return sapling
 	 */
-	public static Optional<Material> getSaplingFromLog(@NonNull Material log) {
+	public static Optional<Material> getSaplingFromLog(@Nonnull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
 
@@ -35,7 +35,7 @@ public final class MaterialConverter {
 	 * @param log log you want to turn into planks
 	 * @return planks
 	 */
-	public static Optional<Material> getPlanksFromLog(@NonNull Material log) {
+	public static Optional<Material> getPlanksFromLog(@Nonnull Material log) {
 		if (!isLog(log))
 			return Optional.empty();
 
@@ -54,7 +54,7 @@ public final class MaterialConverter {
 	 * @param log the material to check
 	 * @return true if the stack is log; false otherwise
 	 */
-	public static boolean isLog(@NonNull Material log) {
+	public static boolean isLog(@Nonnull Material log) {
 		return log.name().endsWith("_LOG") || log.name().endsWith("_WOOD");
 	}
 }


### PR DESCRIPTION
## Description
Latest release of Slimefun is missing MaterialConverter (I think somebody is cleaning up the CSCoreLib mess)
But we need one! 
So basing on decompiled RC25 and latest CSCoreLib I have created this makeshift MaterialConverter inside STB utils package.
It's not beautiful, but it's working!
And we need Nonnull&Nullable so I added projectlombok to POM.

## Changes
1. Restored and adapted MaterialConverter
2. Adapted SawMill and AutoForester
3. ProjectLombok to POM

## Related Issues
#103 in BusyBiscuit's fork.

## Checklist
- [ ok] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ok ] I followed the existing code standards and didn't mess up the formatting.
- [ ok] I did my best to add documentation to any public classes or methods I added.
- [ok ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
